### PR TITLE
Change write characteristic property for nRF52 starter

### DIFF
--- a/nrf52/arduino/sample/sample.ino
+++ b/nrf52/arduino/sample/sample.ino
@@ -66,7 +66,7 @@ void setupServices(void) {
   userService.begin();
 
   writeCharacteristic = BLECharacteristic(writeCharacteristicUUID);
-  writeCharacteristic.setProperties(CHR_PROPS_WRITE_WO_RESP);
+  writeCharacteristic.setProperties(CHR_PROPS_WRITE);
   writeCharacteristic.setWriteCallback(write_led_cb);
   writeCharacteristic.setPermission(SECMODE_ENC_NO_MITM, SECMODE_ENC_NO_MITM);
   writeCharacteristic.setFixedLen(1);


### PR DESCRIPTION
ESP32 and M5Stack starters are using "write with response" for write (LED) characteristic property.
If so, we should use "write with response" property on nRF52 as well.