### PR TITLE
Set ESP_LE_AUTH_BOND to authentication mode for ESP32 devices

### DIFF
--- a/esp32/arduino/sample/sample.ino
+++ b/esp32/arduino/sample/sample.ino
@@ -64,7 +64,7 @@ void setup() {
 
   // Security Settings
   BLESecurity *thingsSecurity = new BLESecurity();
-  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_ONLY);
+  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
   thingsSecurity->setCapability(ESP_IO_CAP_NONE);
   thingsSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 

--- a/m5stack/arduino/sample/sample.ino
+++ b/m5stack/arduino/sample/sample.ino
@@ -68,7 +68,7 @@ void setup() {
 
   // Security Settings
   BLESecurity *thingsSecurity = new BLESecurity();
-  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_ONLY);
+  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
   thingsSecurity->setCapability(ESP_IO_CAP_NONE);
   thingsSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 

--- a/m5stick-c/arduino/sample/sample.ino
+++ b/m5stick-c/arduino/sample/sample.ino
@@ -59,7 +59,7 @@ void setup() {
 
   // Security Settings
   BLESecurity *thingsSecurity = new BLESecurity();
-  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_ONLY);
+  thingsSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
   thingsSecurity->setCapability(ESP_IO_CAP_NONE);
   thingsSecurity->setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
 


### PR DESCRIPTION
`ESP_LE_AUTH_REQ_SC_ONLY` is not useful for automatic communication, because it often shows paring popup... (bonding? paring? store seems to be cleared after power-off)

We used `ESP_LE_AUTH_REQ_SC_ONLY` so far for resolving #6 issue by #7 .
It seems caused by wired "Service Changed" characteristic implementation on esp32-idf. (I'm not sure...)
However, it looks has been resolved with esp32-arduino 1.0.2.
